### PR TITLE
Create monochrome engineering tutoring landing page

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#000" />
+  <text x="32" y="40" text-anchor="middle" font-size="32" font-family="'Helvetica Neue', 'Segoe UI', sans-serif" fill="#fff" letter-spacing="0.3em">J</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tutorías y Cursos de Ingeniería Eléctrica | Juan A. Saavedra</title>
+  <meta name="description" content="Tutorías y cursos en ingeniería y electricidad — normativa, instalaciones, energía solar y LaTeX para ingeniería. Aprende con ejemplos prácticos." />
+  <meta property="og:title" content="Tutorías y Cursos de Ingeniería Eléctrica | Juan A. Saavedra" />
+  <meta property="og:description" content="Tutorías y cursos en ingeniería y electricidad — normativa, instalaciones, energía solar y LaTeX para ingeniería. Aprende con ejemplos prácticos." />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="favicon.svg" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Tutorías y Cursos de Ingeniería Eléctrica | Juan A. Saavedra" />
+  <meta name="twitter:description" content="Tutorías y cursos en ingeniería y electricidad — normativa, instalaciones, energía solar y LaTeX para ingeniería. Aprende con ejemplos prácticos." />
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header" data-animate>
+    <div class="brand"><a href="#hero">SAAVEDRA</a></div>
+    <nav class="site-nav" aria-label="Principal">
+      <ul>
+        <li><a href="#purpose">About</a></li>
+        <li><a href="#courses">Cursos</a></li>
+        <li><a href="#tutorias">Tutorías</a></li>
+        <li><a href="#contact">Contacto</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main>
+    <section id="hero" class="hero" aria-labelledby="hero-title">
+      <div class="layout-narrow">
+        <p class="hero-tag" data-animate data-animate-delay="40ms">Tutorías y cursos en ingeniería eléctrica.</p>
+        <h1 id="hero-title" class="hero-title" data-animate data-animate-delay="120ms">
+          E n s e ñ a n z a e n i n g e n i e r í a y e l e c t r i c i d a d
+        </h1>
+        <p class="hero-subtitle" data-animate data-animate-delay="220ms">
+          Aprende con claridad y foco práctico: normativa, instalaciones, energía solar y herramientas como LaTeX.
+        </p>
+        <div class="hero-links" data-animate data-animate-delay="320ms">
+          <a class="link-inline" href="#courses">Explorar cursos</a>
+          <span aria-hidden="true">/</span>
+          <a class="link-inline" href="#tutorias">Ver tutorías</a>
+        </div>
+      </div>
+    </section>
+
+    <section id="purpose" class="purpose" aria-labelledby="purpose-title">
+      <div class="layout-medium">
+        <h2 id="purpose-title" class="section-title" data-animate>Purpose</h2>
+        <p class="purpose-copy" data-animate data-animate-delay="100ms">
+          Creemos en enseñar con propósito. Cada clase, ejemplo y ejercicio está diseñado para simplificar, inspirar y generar impacto real en tus proyectos eléctricos. Nos enfocamos en lo esencial, reforzamos lo práctico y avanzamos siempre con seguridad y claridad.
+        </p>
+      </div>
+    </section>
+
+    <section id="courses" class="courses" aria-labelledby="courses-title">
+      <div class="layout-wide">
+        <div class="section-header">
+          <h2 id="courses-title" class="section-title" data-animate>Cursos</h2>
+          <p class="section-subtitle" data-animate data-animate-delay="100ms">Programas intensivos y prácticos para avanzar en tu carrera técnica.</p>
+        </div>
+        <div class="courses-grid">
+          <article class="course-card highlight" data-animate data-animate-delay="120ms">
+            <div class="card-body">
+              <h3>Curso de LaTeX para Ingeniería</h3>
+              <p>Escribe documentos técnicos impecables. Plantillas para informes, artículos y reportes de ingeniería.</p>
+              <a class="button" href="https://juanasaavedra.github.io/latex-course/#cta" target="_blank" rel="noopener">Inscríbete aquí</a>
+            </div>
+          </article>
+          <article class="course-card placeholder" data-animate data-animate-delay="200ms">
+            <div class="card-body">
+              <h3>Próximo curso 01</h3>
+              <p class="muted">Próximamente</p>
+            </div>
+          </article>
+          <article class="course-card placeholder" data-animate data-animate-delay="260ms">
+            <div class="card-body">
+              <h3>Próximo curso 02</h3>
+              <p class="muted">Próximamente</p>
+            </div>
+          </article>
+          <article class="course-card placeholder" data-animate data-animate-delay="320ms">
+            <div class="card-body">
+              <h3>Próximo curso 03</h3>
+              <p class="muted">Próximamente</p>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="tutorias" class="tutorias" aria-labelledby="tutorias-title">
+      <div class="layout-wide">
+        <div class="section-header">
+          <h2 id="tutorias-title" class="section-title" data-animate>Tutorías</h2>
+          <p class="section-subtitle" data-animate data-animate-delay="100ms">Asesorías personalizadas para resolver dudas y construir soluciones.</p>
+        </div>
+        <div class="tutoring-grid">
+          <article class="tutoring-card" data-animate data-animate-delay="140ms">
+            <h3>Normativa y cumplimiento</h3>
+            <p>RETIE, NTC, IEEE.</p>
+          </article>
+          <article class="tutoring-card" data-animate data-animate-delay="200ms">
+            <h3>Instalaciones y proyectos</h3>
+            <p>Diseño y revisión eléctrica.</p>
+          </article>
+          <article class="tutoring-card" data-animate data-animate-delay="260ms">
+            <h3>Energía solar y eficiencia</h3>
+            <p>Dimensionamiento y viabilidad.</p>
+          </article>
+          <article class="tutoring-card" data-animate data-animate-delay="320ms">
+            <h3>Automatización y programación</h3>
+            <p>C/C++ aplicado a sistemas.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="cta-final" aria-labelledby="cta-final-title">
+      <div class="layout-medium">
+        <div class="cta-content" data-animate data-animate-delay="100ms">
+          <h2 id="cta-final-title">¿Agendamos tu primera sesión?</h2>
+          <a class="button button-light" href="#contact">Contactar</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer id="contact" class="site-footer" aria-labelledby="footer-title">
+    <div class="layout-wide footer-content">
+      <div class="footer-block" data-animate data-animate-delay="80ms">
+        <h2 id="footer-title">Contacto</h2>
+        <p>Escríbeme para coordinar tu sesión o recibir información de los próximos cursos.</p>
+        <ul class="footer-links">
+          <li><a href="mailto:contacto@juanasaavedra.com">contacto@juanasaavedra.com</a></li>
+          <li><a href="https://www.linkedin.com/in/juanasaavedra/" target="_blank" rel="noopener">LinkedIn</a></li>
+          <li><a href="https://www.instagram.com/juanasaavedra/" target="_blank" rel="noopener">Instagram</a></li>
+        </ul>
+      </div>
+      <div class="footer-meta" data-animate data-animate-delay="160ms">
+        <p>Bogotá, Colombia</p>
+        <p>Hora local: <span data-local-time data-timezone="America/Bogota"></span></p>
+      </div>
+    </div>
+    <div class="layout-wide footer-note">
+      <small>© <span id="year"></span> Juan A. Saavedra. Todos los derechos reservados.</small>
+    </div>
+  </footer>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,74 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const animatedElements = document.querySelectorAll('[data-animate]');
+  const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  const revealImmediately = () => {
+    animatedElements.forEach((element) => {
+      element.classList.add('visible');
+      element.style.removeProperty('--delay');
+    });
+  };
+
+  const registerMotionListener = (callback) => {
+    if (typeof motionQuery.addEventListener === 'function') {
+      motionQuery.addEventListener('change', callback);
+    } else if (typeof motionQuery.addListener === 'function') {
+      motionQuery.addListener(callback);
+    }
+  };
+
+  if (motionQuery.matches) {
+    revealImmediately();
+  } else {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        threshold: 0.2,
+        rootMargin: '0px 0px -10%',
+      }
+    );
+
+    animatedElements.forEach((element, index) => {
+      const delay = element.dataset.animateDelay || `${Math.min(index * 60, 360)}ms`;
+      element.style.setProperty('--delay', delay);
+      observer.observe(element);
+    });
+
+    registerMotionListener((event) => {
+      if (event.matches) {
+        revealImmediately();
+      }
+    });
+  }
+
+  const yearElement = document.getElementById('year');
+  if (yearElement) {
+    yearElement.textContent = new Date().getFullYear();
+  }
+
+  const timeElement = document.querySelector('[data-local-time]');
+  if (timeElement) {
+    const timeZone = timeElement.getAttribute('data-timezone') || Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const updateLocalTime = () => {
+      const now = new Date();
+      const formatter = new Intl.DateTimeFormat('es-CO', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+        timeZone,
+      });
+      timeElement.textContent = formatter.format(now);
+    };
+
+    updateLocalTime();
+    const intervalId = window.setInterval(updateLocalTime, 60000);
+    window.addEventListener('beforeunload', () => window.clearInterval(intervalId));
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,512 @@
+:root {
+  --background: #000;
+  --surface: #111;
+  --surface-mid: #222;
+  --foreground: #fff;
+  --inverse: #000;
+  --muted: #aaa;
+  --transition: 260ms ease;
+  --letter-spacing-wide: 0.35em;
+  --letter-spacing-medium: 0.2em;
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: "Helvetica Neue", "Segoe UI", "Roboto", sans-serif;
+  line-height: 1.7;
+  letter-spacing: 0.03em;
+}
+
+body::selection,
+::selection {
+  background: var(--foreground);
+  color: var(--inverse);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible {
+  outline: 2px solid var(--foreground);
+  outline-offset: 2px;
+}
+
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+section {
+  border-top: 1px solid var(--surface);
+  padding: clamp(5rem, 8vw, 8rem) clamp(1.5rem, 8vw, 8rem);
+}
+
+.layout-narrow,
+.layout-medium,
+.layout-wide {
+  margin: 0 auto;
+}
+
+.layout-narrow {
+  max-width: 48rem;
+}
+
+.layout-medium {
+  max-width: 60rem;
+}
+
+.layout-wide {
+  max-width: 80rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: clamp(1.25rem, 4vw, 2rem) clamp(1.5rem, 6vw, 5rem);
+  background: rgba(0, 0, 0, 0.92);
+  border-bottom: 1px solid var(--surface);
+  letter-spacing: var(--letter-spacing-medium);
+}
+
+.brand a {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wide);
+  font-weight: 600;
+}
+
+.site-nav ul {
+  display: flex;
+  gap: clamp(1rem, 4vw, 2.5rem);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-medium);
+  font-size: 0.75rem;
+}
+
+.site-nav a {
+  position: relative;
+  display: inline-block;
+  padding-block: 0.25rem;
+  transition: opacity var(--transition);
+}
+
+.site-nav a::after {
+  content: "";
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  height: 1px;
+  background: var(--foreground);
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform var(--transition);
+}
+
+.site-nav a:hover,
+.site-nav a:focus-visible {
+  opacity: 0.6;
+}
+
+.site-nav a:hover::after,
+.site-nav a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.hero {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  padding-top: clamp(5rem, 10vw, 10rem);
+}
+
+.hero-tag {
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-medium);
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.hero-title {
+  margin: clamp(1.5rem, 5vw, 3rem) 0 clamp(1rem, 3vw, 2rem);
+  font-size: clamp(2.6rem, 5.4vw, 5.5rem);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+  line-height: 1.35;
+}
+
+.hero-subtitle {
+  max-width: 40rem;
+  font-size: clamp(1.05rem, 2vw, 1.4rem);
+}
+
+.hero-links {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-top: clamp(1.5rem, 3vw, 2.5rem);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.link-inline {
+  position: relative;
+  padding-bottom: 0.1rem;
+}
+
+.link-inline::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 1px;
+  background: var(--foreground);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--transition);
+}
+
+.link-inline:hover::after,
+.link-inline:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.section-title {
+  text-transform: uppercase;
+  font-size: clamp(1.25rem, 2.2vw, 1.9rem);
+  letter-spacing: 0.28em;
+  margin-bottom: clamp(2rem, 3vw, 3rem);
+}
+
+.section-subtitle {
+  max-width: 40rem;
+  font-size: clamp(1rem, 2vw, 1.3rem);
+  color: rgba(255, 255, 255, 0.74);
+}
+
+.purpose-copy {
+  font-size: clamp(1.15rem, 2.4vw, 1.55rem);
+  letter-spacing: 0.08em;
+  line-height: 1.9;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.courses {
+  background: linear-gradient(to bottom, transparent 0%, rgba(34, 34, 34, 0.15) 100%);
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: clamp(3rem, 5vw, 4rem);
+}
+
+.courses-grid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.course-card {
+  border: 1px solid var(--surface-mid);
+  padding: clamp(2rem, 3vw, 3rem);
+  min-height: 18rem;
+  display: flex;
+  align-items: flex-end;
+  transition: transform var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
+}
+
+.course-card .card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.course-card h3 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.course-card p {
+  font-size: 0.95rem;
+  max-width: 22rem;
+}
+
+.course-card.highlight {
+  background: var(--foreground);
+  color: var(--inverse);
+}
+
+.course-card.highlight .button {
+  background: var(--inverse);
+  color: var(--foreground);
+}
+
+.course-card.highlight .button:hover,
+.course-card.highlight .button:focus-visible {
+  background: transparent;
+  color: var(--inverse);
+}
+
+.course-card:hover,
+.course-card:focus-within {
+  transform: translateY(-6px);
+  border-color: var(--foreground);
+}
+
+.placeholder {
+  background: transparent;
+}
+
+.placeholder .muted {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.tutoring-grid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.tutoring-card {
+  border: 1px solid var(--surface-mid);
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  min-height: 12rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transition: background var(--transition), color var(--transition), transform var(--transition);
+}
+
+.tutoring-card h3 {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+}
+
+.tutoring-card p {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.tutoring-card:hover,
+.tutoring-card:focus-within {
+  background: var(--foreground);
+  color: var(--inverse);
+  transform: translateY(-4px);
+}
+
+.tutoring-card:hover p,
+.tutoring-card:focus-within p {
+  color: var(--inverse);
+}
+
+.cta-final {
+  border-top: 1px solid var(--surface);
+  padding-block: clamp(4rem, 7vw, 6rem);
+}
+
+.cta-content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  align-items: flex-start;
+}
+
+.cta-content h2 {
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.8rem;
+  border: 1px solid currentColor;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  transition: background var(--transition), color var(--transition);
+}
+
+.button:hover,
+.button:focus-visible {
+  background: var(--foreground);
+  color: var(--inverse);
+}
+
+.button-light {
+  background: transparent;
+  color: var(--foreground);
+}
+
+.site-footer {
+  border-top: 1px solid var(--surface);
+  padding: clamp(4rem, 7vw, 6rem) clamp(1.5rem, 8vw, 8rem);
+}
+
+.footer-content {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  align-items: flex-start;
+  margin-bottom: clamp(3rem, 6vw, 4rem);
+}
+
+.footer-block h2 {
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  font-size: 1.1rem;
+  margin-bottom: 1.5rem;
+}
+
+.footer-block p {
+  max-width: 28rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.footer-links {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 2rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.footer-links a {
+  position: relative;
+  width: fit-content;
+}
+
+.footer-links a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.2rem;
+  width: 100%;
+  height: 1px;
+  background: var(--foreground);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--transition);
+}
+
+.footer-links a:hover::after,
+.footer-links a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.footer-meta {
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.footer-note {
+  border-top: 1px solid var(--surface);
+  padding-top: 2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+[data-animate] {
+  opacity: 0;
+  transform: translateY(28px);
+  transition: opacity var(--transition), transform var(--transition);
+  transition-delay: var(--delay, 0ms);
+}
+
+[data-animate].visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  [data-animate] {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .site-header {
+    flex-direction: column;
+    gap: 1.5rem;
+    align-items: flex-start;
+  }
+
+  .site-nav ul {
+    gap: 1.5rem;
+  }
+
+  .hero-links {
+    flex-wrap: wrap;
+  }
+
+  .section-title {
+    letter-spacing: 0.22em;
+  }
+
+  .courses-grid,
+  .tutoring-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-title {
+    letter-spacing: 0.28em;
+  }
+
+  .site-nav ul {
+    font-size: 0.7rem;
+  }
+
+  .button {
+    width: 100%;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary
- craft a single-page HTML layout that mirrors the manifesto-style storytelling for engineering tutoring, covering hero, purpose, cursos, tutorías, and contact sections
- add a monochrome visual system with wide-tracking typography, responsive grids, and subtle hover/scroll animations in CSS
- implement IntersectionObserver-driven reveals, local time display, and a black-and-white favicon for branding polish

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d06f0452f48329a1ff8282d27174d5